### PR TITLE
feat: update Merit incentives to support supply and borrow incentive …

### DIFF
--- a/src/hooks/useMeritIncentives.ts
+++ b/src/hooks/useMeritIncentives.ts
@@ -29,44 +29,54 @@ export type MeritReserveIncentiveData = Omit<ReserveIncentiveResponse, 'incentiv
   customMessage?: string;
 };
 
-const getMeritData = (market: string, symbol: string): MeritReserveIncentiveData | undefined =>
+const getMeritData = (market: string, symbol: string): MeritReserveIncentiveData[] | undefined =>
   MERIT_DATA_MAP[market]?.[symbol];
 
-const MERIT_DATA_MAP: Record<string, Record<string, MeritReserveIncentiveData>> = {
+const MERIT_DATA_MAP: Record<string, Record<string, MeritReserveIncentiveData[]>> = {
   [CustomMarket.proto_mainnet_v3]: {
-    GHO: {
-      action: MeritAction.ETHEREUM_STKGHO,
-      rewardTokenAddress: AaveV3Ethereum.ASSETS.GHO.UNDERLYING,
-      rewardTokenSymbol: 'GHO',
-    },
-    cbBTC: {
-      action: MeritAction.SUPPLY_CBBTC_BORROW_USDC,
-      rewardTokenAddress: AaveV3Ethereum.ASSETS.USDC.A_TOKEN,
-      rewardTokenSymbol: 'aEthUSDC',
-      protocolAction: ProtocolAction.supply,
-      customMessage: 'You must supply cbBTC and borrow USDC in order to receive merit rewards.',
-    },
-    USDC: {
-      action: MeritAction.SUPPLY_CBBTC_BORROW_USDC,
-      rewardTokenAddress: AaveV3Ethereum.ASSETS.USDC.A_TOKEN,
-      rewardTokenSymbol: 'aEthUSDC',
-      protocolAction: ProtocolAction.borrow,
-      customMessage: 'You must supply cbBTC and borrow USDC in order to receive merit rewards.',
-    },
-    WBTC: {
-      action: MeritAction.SUPPLY_WBTC_BORROW_USDT,
-      rewardTokenAddress: AaveV3Ethereum.ASSETS.USDT.A_TOKEN,
-      rewardTokenSymbol: 'aEthUSDT',
-      protocolAction: ProtocolAction.supply,
-      customMessage: 'You must supply wBTC and borrow USDT in order to receive merit rewards.',
-    },
-    USDT: {
-      action: MeritAction.SUPPLY_WBTC_BORROW_USDT,
-      rewardTokenAddress: AaveV3Ethereum.ASSETS.USDT.A_TOKEN,
-      rewardTokenSymbol: 'aEthUSDT',
-      protocolAction: ProtocolAction.borrow,
-      customMessage: 'You must supply wBTC and borrow USDT in order to receive merit rewards.',
-    },
+    GHO: [
+      {
+        action: MeritAction.ETHEREUM_STKGHO,
+        rewardTokenAddress: AaveV3Ethereum.ASSETS.GHO.UNDERLYING,
+        rewardTokenSymbol: 'GHO',
+      },
+    ],
+    cbBTC: [
+      {
+        action: MeritAction.SUPPLY_CBBTC_BORROW_USDC,
+        rewardTokenAddress: AaveV3Ethereum.ASSETS.USDC.A_TOKEN,
+        rewardTokenSymbol: 'aEthUSDC',
+        protocolAction: ProtocolAction.supply,
+        customMessage: 'You must supply cbBTC and borrow USDC in order to receive merit rewards.',
+      },
+    ],
+    USDC: [
+      {
+        action: MeritAction.SUPPLY_CBBTC_BORROW_USDC,
+        rewardTokenAddress: AaveV3Ethereum.ASSETS.USDC.A_TOKEN,
+        rewardTokenSymbol: 'aEthUSDC',
+        protocolAction: ProtocolAction.borrow,
+        customMessage: 'You must supply cbBTC and borrow USDC in order to receive merit rewards.',
+      },
+    ],
+    WBTC: [
+      {
+        action: MeritAction.SUPPLY_WBTC_BORROW_USDT,
+        rewardTokenAddress: AaveV3Ethereum.ASSETS.USDT.A_TOKEN,
+        rewardTokenSymbol: 'aEthUSDT',
+        protocolAction: ProtocolAction.supply,
+        customMessage: 'You must supply wBTC and borrow USDT in order to receive merit rewards.',
+      },
+    ],
+    USDT: [
+      {
+        action: MeritAction.SUPPLY_WBTC_BORROW_USDT,
+        rewardTokenAddress: AaveV3Ethereum.ASSETS.USDT.A_TOKEN,
+        rewardTokenSymbol: 'aEthUSDT',
+        protocolAction: ProtocolAction.borrow,
+        customMessage: 'You must supply wBTC and borrow USDT in order to receive merit rewards.',
+      },
+    ],
   },
 };
 
@@ -94,17 +104,21 @@ export const useMeritIncentives = ({
       if (!meritReserveIncentiveData) {
         return null;
       }
-      if (meritReserveIncentiveData.protocolAction !== protocolAction) {
+      const incentive = meritReserveIncentiveData.find(
+        (item) => item.protocolAction === protocolAction
+      );
+
+      if (!incentive) {
         return null;
       }
 
-      const APR = data.actionsAPR[meritReserveIncentiveData.action];
+      const APR = data.actionsAPR[incentive.action];
 
       return {
         incentiveAPR: (APR / 100).toString(),
-        rewardTokenAddress: meritReserveIncentiveData.rewardTokenAddress,
-        rewardTokenSymbol: meritReserveIncentiveData.rewardTokenSymbol,
-        customMessage: meritReserveIncentiveData.customMessage,
+        rewardTokenAddress: incentive.rewardTokenAddress,
+        rewardTokenSymbol: incentive.rewardTokenSymbol,
+        customMessage: incentive.customMessage,
       } as ExtendedReserveIncentiveResponse;
     },
   });


### PR DESCRIPTION
…

## General Changes

As some new liquidity mining (LM) programs will need to pass through Merit due to the standard LM workflow not being adapted for their asset decimals, we will very soon require Merit programs that can run in parallel—one program for the supply side and one for the borrow side. This PR addresses that need.

## Developer Notes

When been implemented these change will be used to launch 3 Base LM programs

---

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
